### PR TITLE
add supports for 1.20~1.23

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -31,6 +31,431 @@ jobs:
         run: |
           make verify-patch-format
 
+  Test-v1-23-4-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-23-4-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.23.4-lts.1
+        run: |
+          make v1.23.4-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test
+        run: |
+          make test
+
+  Test-Cmd-v1-23-4-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-23-4-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.23.4-lts.1
+        run: |
+          make v1.23.4-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test cmd
+        run: |
+          make test-cmd
+
+  Test-Integration-v1-23-4-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+            /tmp/kubernetes-lts/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-23-4-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.23.4-lts.1
+        run: |
+          make v1.23.4-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test integration
+        run: |
+          make test-integration
+
+  Test-v1-22-7-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-22-7-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.22.7-lts.1
+        run: |
+          make v1.22.7-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test
+        run: |
+          make test
+
+  Test-Cmd-v1-22-7-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-22-7-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.22.7-lts.1
+        run: |
+          make v1.22.7-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test cmd
+        run: |
+          make test-cmd
+
+  Test-Integration-v1-22-7-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+            /tmp/kubernetes-lts/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-22-7-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.22.7-lts.1
+        run: |
+          make v1.22.7-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test integration
+        run: |
+          make test-integration
+
+  Test-v1-21-10-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-21-10-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.21.10-lts.1
+        run: |
+          make v1.21.10-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test
+        run: |
+          make test
+
+  Test-Cmd-v1-21-10-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-21-10-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.21.10-lts.1
+        run: |
+          make v1.21.10-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test cmd
+        run: |
+          make test-cmd
+
+  Test-Integration-v1-21-10-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+            /tmp/kubernetes-lts/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-21-10-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.21.10-lts.1
+        run: |
+          make v1.21.10-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test integration
+        run: |
+          make test-integration
+
+  Test-v1-20-16-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-20-16-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.20.16-lts.1
+        run: |
+          make v1.20.16-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test
+        run: |
+          make test
+
+  Test-Cmd-v1-20-16-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-20-16-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.20.16-lts.1
+        run: |
+          make v1.20.16-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test cmd
+        run: |
+          make test-cmd
+
+  Test-Integration-v1-20-16-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+            /tmp/kubernetes-lts/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-20-16-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.20.16-lts.1
+        run: |
+          make v1.20.16-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test integration
+        run: |
+          make test-integration
+
+  Test-v1-20-2-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-20-2-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.20.2-lts.1
+        run: |
+          make v1.20.2-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test
+        run: |
+          make test
+
+  Test-Cmd-v1-20-2-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-20-2-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.20.2-lts.1
+        run: |
+          make v1.20.2-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test cmd
+        run: |
+          make test-cmd
+
+  Test-Integration-v1-20-2-lts-1:
+    needs: Patch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: src
+        with:
+          path: |
+            src
+            /tmp/kubernetes-lts/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-v1-20-2-lts-1
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+      - name: Install dependent
+        run: |
+          make dependent
+      - name: Checkout to v1.20.2-lts.1
+        run: |
+          make v1.20.2-lts.1
+      - name: Install etcd
+        run: |
+          make install-etcd
+      - name: Test integration
+        run: |
+          make test-integration
+
   Test-v1-19-16-lts-2:
     needs: Patch
     runs-on: ubuntu-latest

--- a/releases.yml
+++ b/releases.yml
@@ -1,6 +1,37 @@
 base: https://github.com/kubernetes/kubernetes
 
 releases:
+
+  - name: v1.23.4-lts.1
+    base_release: v1.19.16-ci
+    must: true
+    patches:
+      - nokmem.1.19
+
+  - name: v1.22.7-lts.1
+    base_release: v1.19.16-ci
+    must: true
+    patches:
+      - nokmem.1.19
+
+  - name: v1.21.10-lts.1
+    base_release: v1.19.16-ci
+    must: true
+    patches:
+      - nokmem.1.19
+
+  - name: v1.20.16-lts.1
+    base_release: v1.19.16-ci
+    must: true
+    patches:
+      - nokmem.1.19
+
+  - name: v1.20.2-lts.1
+    base_release: v1.19.16-ci
+    must: true
+    patches:
+      - nokmem.1.19
+
   - name: v1.19.16-lts.2
     base_release: v1.19.16-ci
     must: true


### PR DESCRIPTION
1.20.2/1.20.16/1.21.10/1.22.7/1.23.4

Signed-off-by: Paco Xu <paco.xu@daocloud.io>

#### What type of PR is this?
/kind feature


#### What this PR does / why we need it:
Fixes https://github.com/klts-io/kubernetes-lts/issues/121

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
add supports for 1.20~1.23: 1.20.2/1.20.16/1.21.10/1.22.7/1.23.4
```
