### PR TITLE
test(v1.18.20-ci): tolerate failing x509 auth UT in Test-v1-18-20-lts-2

### DIFF
--- a/releases.yml
+++ b/releases.yml
@@ -379,6 +379,7 @@ releases:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
+      - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
     test_integration_failures_tolerated: []
 


### PR DESCRIPTION
## Summary
- add k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509 to test_failures_tolerated for v1.18.20-ci
- align with hack/test.sh exact package matching so retry excludes this known expired-cert UT package

## Why
GitHub Actions run 24115194694, job Test-v1-18-20-lts-2 (70357983544) fails after retries with remaining case:
- k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509

The logs show: x509: certificate has expired or is not yet valid.

## Scope
- only updates v1.18.20-ci test tolerance list
