### PR TITLE
Add CVE-2021-25740 mitigation patch for <=1.21

### DIFF
--- a/patches/CVE-2021-25740.1.21.patch
+++ b/patches/CVE-2021-25740.1.21.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Codex <codex@example.com>
+Date: Thu, 9 Apr 2026 14:45:43 +0800
+Subject: [PATCH] Remove Endpoints write access from aggregated edit role
+
+---
+ plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go       | 2 +-
+ .../authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml | 1 -
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+index a7779186043..809fcf0535d 100644
+--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
++++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+@@ -285,7 +285,7 @@ func ClusterRoles() []rbacv1.ClusterRole {
+ 
+ 				rbacv1helpers.NewRule(Write...).Groups(legacyGroup).Resources("pods", "pods/attach", "pods/proxy", "pods/exec", "pods/portforward").RuleOrDie(),
+ 				rbacv1helpers.NewRule(Write...).Groups(legacyGroup).Resources("replicationcontrollers", "replicationcontrollers/scale", "serviceaccounts",
+-					"services", "services/proxy", "endpoints", "persistentvolumeclaims", "configmaps", "secrets").RuleOrDie(),
++					"services", "services/proxy", "persistentvolumeclaims", "configmaps", "secrets").RuleOrDie(),
+ 
+ 				rbacv1helpers.NewRule(Write...).Groups(appsGroup).Resources(
+ 					"statefulsets", "statefulsets/scale",
+diff --git a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+index 4fe18334ec7..448587df88c 100644
+--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
++++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+@@ -128,7 +128,6 @@ items:
+     - ""
+     resources:
+     - configmaps
+-    - endpoints
+     - persistentvolumeclaims
+     - replicationcontrollers
+     - replicationcontrollers/scale

--- a/releases.yml
+++ b/releases.yml
@@ -66,12 +66,14 @@ releases:
   - name: v1.21.14-lts.1
     base_release: v1.21.14-ci
     must: true
-    patches: []
+    patches:
+      - CVE-2021-25740.1.21
 
   - name: v1.20.15-lts.2
     base_release: v1.20.15-ci
     must: true
     patches:
+      - CVE-2021-25740.1.21
       - fix-kubectl-convert-97644.1.20 
       - nokmem.1.20
 
@@ -87,6 +89,7 @@ releases:
     base_release: v1.19.16-ci
     must: true
     patches:
+      - CVE-2021-25740.1.21
       - CVE-2020-8554.1.19
       - nokmem.1.20
 
@@ -94,6 +97,7 @@ releases:
     base_release: v1.18.20-ci
     must: true
     patches:
+      - CVE-2021-25740.1.21
       - CVE-2020-8554.1.18
       - fix-missing-env-91500.1.18
       - CVE-2021-25741.1.18
@@ -657,6 +661,14 @@ patches:
       - https://github.com/kubernetes/kubernetes/pull/75771.patch
 
   # CVSS Score >= 3.0
+
+  # CVSS Score 3.1, <= k8s1.21, https://www.cvedetails.com/cve/CVE-2021-25740/
+  - name: CVE-2021-25740
+    patch:
+      - https://github.com/kubernetes/kubernetes/pull/103704.patch
+  - name: CVE-2021-25740.1.21
+    patch:
+      - patches/CVE-2021-25740.1.21.patch # Conflict resolution for <=1.21
 
   # CVSS Score 3.3, < k8s1.15, https://www.cvedetails.com/cve/CVE-2020-8551/
   # TODO


### PR DESCRIPTION
Fixes #64

## Summary
- add a conflict-resolved patch `CVE-2021-25740.1.21` to remove `endpoints` write permission from `system:aggregate-to-edit`
- wire the patch into maintained LTS releases: `v1.18.20-lts.2`, `v1.19.16-lts.3`, `v1.20.15-lts.2`, `v1.21.14-lts.1`
- document upstream source patch for CVE-2021-25740 in `releases.yml`

## Notes
- this follows upstream partial mitigation from kubernetes/kubernetes#103704
- upstream advisory states there is no complete patch for all affected configurations
