### PR TITLE
Add CVE-2024-10220 patch mapping for maintained release lines

### DIFF
--- a/patches/CVE-2024-10220.1.18.patch
+++ b/patches/CVE-2024-10220.1.18.patch
@@ -1,4 +1,4 @@
-From 1c74ee1083235bba70af330b72d076e60144570f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paco Xu <paco.xu@daocloud.io>
 Date: Sun, 12 Apr 2026 15:48:53 +0800
 Subject: [PATCH] gitRepo test: use gitUrl in invalid revision+directory case
@@ -21,6 +21,3 @@ index 1baf4c6efe3..0f14159d5d1 100644
  						Revision:   "main",
  						Directory:  "foo/bar",
  					},
--- 
-2.50.1 (Apple Git-155)
-

--- a/patches/CVE-2024-10220.1.18.patch
+++ b/patches/CVE-2024-10220.1.18.patch
@@ -1,0 +1,26 @@
+From 1c74ee1083235bba70af330b72d076e60144570f Mon Sep 17 00:00:00 2001
+From: Paco Xu <paco.xu@daocloud.io>
+Date: Sun, 12 Apr 2026 15:48:53 +0800
+Subject: [PATCH] gitRepo test: use gitUrl in invalid revision+directory case
+ for <=1.18
+
+---
+ pkg/volume/git_repo/git_repo_test.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkg/volume/git_repo/git_repo_test.go b/pkg/volume/git_repo/git_repo_test.go
+index 1baf4c6efe3..0f14159d5d1 100644
+--- a/pkg/volume/git_repo/git_repo_test.go
++++ b/pkg/volume/git_repo/git_repo_test.go
+@@ -272,7 +272,7 @@ func TestPlugin(t *testing.T) {
+ 				Name: "vol1",
+ 				VolumeSource: v1.VolumeSource{
+ 					GitRepo: &v1.GitRepoVolumeSource{
+-						Repository: gitURL,
++						Repository: gitUrl,
+ 						Revision:   "main",
+ 						Directory:  "foo/bar",
+ 					},
+-- 
+2.50.1 (Apple Git-155)
+

--- a/releases.yml
+++ b/releases.yml
@@ -271,6 +271,7 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -280,6 +281,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -291,6 +293,7 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
       - codegens-to-scripts.1.25
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -302,6 +305,7 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
       - codegens-to-scripts.1.24
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -312,6 +316,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -322,6 +327,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -332,6 +338,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -342,6 +349,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -355,6 +363,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -370,6 +379,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -384,6 +394,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/volume/csi
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
@@ -399,6 +410,7 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-health.1.16
       - fix-etcd-put-key.1.23
+      - CVE-2024-10220
     test_failures_tolerated:
       # - k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions # Fix by fix-test.1.16
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
@@ -490,6 +502,11 @@ releases:
 
 patches:
   # CVSS Score >= 8.0
+
+  # CVSS Score 8.1, <= k8s1.28.11, https://www.cvedetails.com/cve/CVE-2024-10220/
+  - name: CVE-2024-10220
+    patch:
+      - https://github.com/kubernetes/kubernetes/pull/124531.patch
 
   # CVSS Score 8.8, < k8s1.19, https://www.cvedetails.com/cve/CVE-2021-25741/
   - name: CVE-2021-25741

--- a/releases.yml
+++ b/releases.yml
@@ -379,7 +379,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
-      - CVE-2024-10220
+      - CVE-2024-10220.1.18
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -394,7 +394,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
-      - CVE-2024-10220
+      - CVE-2024-10220.1.18
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/volume/csi
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
@@ -410,7 +410,7 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-health.1.16
       - fix-etcd-put-key.1.23
-      - CVE-2024-10220
+      - CVE-2024-10220.1.18
     test_failures_tolerated:
       # - k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions # Fix by fix-test.1.16
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
@@ -507,6 +507,10 @@ patches:
   - name: CVE-2024-10220
     patch:
       - https://github.com/kubernetes/kubernetes/pull/124531.patch
+  - name: CVE-2024-10220.1.18
+    patch:
+      - https://github.com/kubernetes/kubernetes/pull/124531.patch
+      - patches/CVE-2024-10220.1.18.patch # Conflict resolution
 
   # CVSS Score 8.8, < k8s1.19, https://www.cvedetails.com/cve/CVE-2021-25741/
   - name: CVE-2021-25741


### PR DESCRIPTION
## Summary
- add a CVE-2024-10220 patch entry in releases.yml mapped to upstream Kubernetes fix patch kubernetes/kubernetes#124531
- attach CVE-2024-10220 to maintained vulnerable CI release bases (v1.27.16-ci down to v1.16.15-ci) so derived LTS tags inherit the fix
- keep unsupported older lines unchanged

## Validation
- make verify-releases
- YAML parse check with yq
- dry-run patch apply (git am -3) verified on representative tags: v1.27.16, v1.24.17, v1.16.15

Fixes #217