### PR TITLE
Add 5 CVE patch mappings for maintained release lines

### DIFF
--- a/patches/CVE-2025-13281.patch
+++ b/patches/CVE-2025-13281.patch
@@ -1,0 +1,71 @@
+From 6f3b872e450e8f00c3ca4a7f9819f9443187db61 Mon Sep 17 00:00:00 2001
+From: Paco Xu <paco.xu@daocloud.io>
+Date: Mon, 13 Apr 2026 18:48:41 +0800
+Subject: [PATCH] CVE-2025-13281: avoid leaking backend errors in Portworx
+ events
+
+---
+ pkg/volume/portworx/portworx.go | 33 +++++++++++++++++++++++++--------
+ 1 file changed, 25 insertions(+), 8 deletions(-)
+
+diff --git a/pkg/volume/portworx/portworx.go b/pkg/volume/portworx/portworx.go
+index baa623ab4b4..1d96d03633e 100644
+--- a/pkg/volume/portworx/portworx.go
++++ b/pkg/volume/portworx/portworx.go
+@@ -309,4 +309,5 @@ func (b *portworxVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterAr
+ 	if err != nil && !os.IsNotExist(err) {
+-		klog.Errorf("Cannot validate mountpoint: %s", dir)
+-		return err
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Cannot validate mountpoint %s: %v", dir, err)
++		return fmt.Errorf("failed to validate mountpoint: see kube-controller-manager.log for details")
+ 	}
+@@ -320,3 +321,5 @@ func (b *portworxVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterAr
+ 	if _, err := b.manager.AttachVolume(b, attachOptions); err != nil {
+-		return err
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Failed to attach volume %s: %v", b.volumeID, err)
++		return fmt.Errorf("failed to attach volume: see kube-controller-manager.log for details")
+ 	}
+@@ -330,3 +333,5 @@ func (b *portworxVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterAr
+ 	if err := b.manager.MountVolume(b, dir); err != nil {
+-		return err
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Failed to mount volume %s: %v", b.volumeID, err)
++		return fmt.Errorf("failed to mount volume: see kube-controller-manager.log for details")
+ 	}
+@@ -361,3 +366,5 @@ func (c *portworxVolumeUnmounter) TearDownAt(dir string) error {
+ 	if err := c.manager.UnmountVolume(c, dir); err != nil {
+-		return err
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Failed to unmount volume %s: %v", c.volumeID, err)
++		return fmt.Errorf("failed to unmount volume: see kube-controller-manager.log for details")
+ 	}
+@@ -366,3 +373,5 @@ func (c *portworxVolumeUnmounter) TearDownAt(dir string) error {
+ 	if err := c.manager.DetachVolume(c); err != nil {
+-		return err
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Failed to detach volume %s: %v", c.volumeID, err)
++		return fmt.Errorf("failed to detach volume: see kube-controller-manager.log for details")
+ 	}
+@@ -383,3 +392,9 @@ func (d *portworxVolumeDeleter) GetPath() string {
+ func (d *portworxVolumeDeleter) Delete() error {
+-	return d.manager.DeleteVolume(d)
++	err := d.manager.DeleteVolume(d)
++	if err != nil {
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Failed to delete volume %s: %v", d.volumeID, err)
++		return fmt.Errorf("failed to delete volume: see kube-controller-manager.log for details")
++	}
++	return nil
+ }
+@@ -404,3 +419,5 @@ func (c *portworxVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTopo
+ 	if err != nil {
+-		return nil, err
++		// don't log error details from client calls in events
++		klog.V(4).Infof("Failed to create volume: %v", err)
++		return nil, fmt.Errorf("failed to create volume: see kube-controller-manager.log for details")
+ 	}
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/CVE-2025-1767.patch
+++ b/patches/CVE-2025-1767.patch
@@ -1,0 +1,22 @@
+From d7848112041d6e6e81b41b53574b589e81709a20 Mon Sep 17 00:00:00 2001
+From: Paco Xu <paco.xu@daocloud.io>
+Date: Tue, 14 Apr 2026 09:58:03 +0800
+Subject: [PATCH] CVE-2025-1767: reject local paths for gitRepo repository
+
+---
+ pkg/volume/git_repo/git_repo.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/pkg/volume/git_repo/git_repo.go b/pkg/volume/git_repo/git_repo.go
+index 932296c2845..e281a5384b0 100644
+--- a/pkg/volume/git_repo/git_repo.go
++++ b/pkg/volume/git_repo/git_repo.go
+@@ -262,2 +262,5 @@ func validateVolume(src *v1.GitRepoVolumeSource) error {
+ 	}
++	if filepath.IsAbs(src.Repository) || strings.HasPrefix(strings.ToLower(src.Repository), "file://") || strings.HasPrefix(src.Repository, "./") || strings.HasPrefix(src.Repository, "../") {
++		return fmt.Errorf("%q is an invalid value for repository", src.Repository)
++	}
+ 	if err := validateNonFlagArgument(src.Revision, "revision"); err != nil {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/CVE-2025-5187.patch
+++ b/patches/CVE-2025-5187.patch
@@ -1,0 +1,24 @@
+From f1840c56cd70e676a5f09ad483f70b12833e75aa Mon Sep 17 00:00:00 2001
+From: Paco Xu <paco.xu@daocloud.io>
+Date: Tue, 14 Apr 2026 13:46:56 +0800
+Subject: [PATCH] CVE-2025-5187: block ownerReference updates by node users
+
+---
+ plugin/pkg/admission/noderestriction/admission.go | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/plugin/pkg/admission/noderestriction/admission.go b/plugin/pkg/admission/noderestriction/admission.go
+index c4870d27a23..03efd7d3bf2 100644
+--- a/plugin/pkg/admission/noderestriction/admission.go
++++ b/plugin/pkg/admission/noderestriction/admission.go
+@@ -391,2 +391,7 @@ func (p *Plugin) admitNode(nodeName string, a admission.Attributes) error {
+ 
++		// Don't allow a node to update its own ownerReferences.
++		if !apiequality.Semantic.DeepEqual(node.OwnerReferences, oldNode.OwnerReferences) {
++			return admission.NewForbidden(a, fmt.Errorf("node %q is not allowed to modify ownerReferences", nodeName))
++		}
++
+ 		// Don't allow a node to update labels outside the allowed set.
+-- 
+2.50.1 (Apple Git-155)
+

--- a/releases.yml
+++ b/releases.yml
@@ -231,6 +231,11 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2024-9042
+      - CVE-2025-0426
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -239,6 +244,7 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2025-1767
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -247,6 +253,8 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2025-13281
+      - CVE-2025-1767
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -255,6 +263,9 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -263,6 +274,9 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -272,6 +286,11 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
       - CVE-2024-10220
+      - CVE-2024-9042
+      - CVE-2025-0426
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
 
@@ -282,6 +301,10 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
       - CVE-2024-10220
+      - CVE-2025-0426
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -294,6 +317,10 @@ releases:
       - fix-etcd-put-key.1.24
       - codegens-to-scripts.1.25
       - CVE-2024-10220
+      - CVE-2025-0426
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -306,6 +333,9 @@ releases:
       - fix-etcd-put-key.1.24
       - codegens-to-scripts.1.24
       - CVE-2024-10220
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -317,6 +347,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -328,6 +361,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -339,6 +375,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/azure
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/authentication/request/x509
@@ -350,6 +389,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -364,6 +406,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -380,6 +425,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220.1.18
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/kubelet/volumemanager/reconciler
       - k8s.io/kubernetes/pkg/volume/csi
@@ -395,6 +443,9 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
       - CVE-2024-10220.1.18
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       - k8s.io/kubernetes/pkg/volume/csi
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
@@ -411,6 +462,9 @@ releases:
       - fix-etcd-health.1.16
       - fix-etcd-put-key.1.23
       - CVE-2024-10220.1.18
+      - CVE-2025-13281
+      - CVE-2025-1767
+      - CVE-2025-5187
     test_failures_tolerated:
       # - k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions # Fix by fix-test.1.16
       - k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server
@@ -567,7 +621,32 @@ patches:
     patch:
       - patches/CVE-2019-11247.1.11.patch # Remove BUILD file
 
+  # CVSS Score 6.7, <= k8s1.31.11 on supported lines, https://github.com/kubernetes/kubernetes/issues/133471
+  - name: CVE-2025-5187
+    patch:
+      - patches/CVE-2025-5187.patch # Backport without test changes for <=1.30 lines
+
+  # CVSS Score 6.5, all k8s versions, https://github.com/kubernetes/kubernetes/issues/130786
+  - name: CVE-2025-1767
+    patch:
+      - patches/CVE-2025-1767.patch # Mitigate local repository path access in gitRepo volume
+
+  # CVSS Score 6.2, <= k8s1.29.13 on supported lines, https://github.com/kubernetes/kubernetes/issues/130016
+  - name: CVE-2025-0426
+    patch:
+      - https://github.com/kubernetes/kubernetes/pull/130014.patch
+
   # CVSS Score >= 5.0
+
+  # CVSS Score 5.9, <= k8s1.29.12 on supported lines, https://github.com/kubernetes/kubernetes/issues/129654
+  - name: CVE-2024-9042
+    patch:
+      - https://github.com/kubernetes/kubernetes/pull/129603.patch
+
+  # CVSS Score 5.8, <= k8s1.31.14 on supported lines, https://github.com/kubernetes/kubernetes/issues/135525
+  - name: CVE-2025-13281
+    patch:
+      - patches/CVE-2025-13281.patch # Reduced-context backport for <=1.31 lines
 
   # CVSS Score 5.8, < k8s1.16, https://www.cvedetails.com/cve/CVE-2020-8558/
   - name: CVE-2020-8558


### PR DESCRIPTION
## Summary
- add maintained-line mappings for CVE-2024-9042, CVE-2025-0426, CVE-2025-13281, CVE-2025-1767, and CVE-2025-5187
- add local backport patch patches/CVE-2025-13281.patch (Portworx event error redaction)
- add local mitigation patch patches/CVE-2025-1767.patch (reject local path/file URL in gitRepo repository)
- add local backport patch patches/CVE-2025-5187.patch (forbid node ownerReferences update)

## Validation
- `PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" ./hack/format_patch.sh patches/CVE-2025-13281.patch`
- `PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" ./hack/format_patch.sh patches/CVE-2025-1767.patch`
- `PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" ./hack/format_patch.sh patches/CVE-2025-5187.patch`
- `PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" ./hack/verify_patch_format.sh`
- `PATH="/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH" ./hack/verify_releases.sh`

Closes #216
Closes #218
Closes #219
Closes #221
Closes #222
