### PR TITLE
Fix release image push for legacy k8s.gcr.io tags

### DIFF
--- a/hack/image_manifest_push.sh
+++ b/hack/image_manifest_push.sh
@@ -10,6 +10,16 @@ cd "${WORKDIR}"
 REGISTRY=${REGISTRY:-}
 TAG=$(helper::workdir::version)
 
+if [[ -z "${REGISTRY}" ]]; then
+    echo "REGISTRY is required"
+    exit 1
+fi
+
+if [[ "${REGISTRY}" != ghcr.io/* ]]; then
+    echo "REGISTRY must target ghcr.io, got: ${REGISTRY}"
+    exit 1
+fi
+
 DOCKER_CLI_EXPERIMENTAL=enabled
 
 docker images

--- a/hack/image_manifest_retags.sh
+++ b/hack/image_manifest_retags.sh
@@ -7,6 +7,16 @@ set -o pipefail
 REGISTRY=${REGISTRY:-}
 IMAGES="$@"
 
+if [[ -z "${REGISTRY}" ]]; then
+    echo "REGISTRY is required"
+    exit 1
+fi
+
+if [[ "${REGISTRY}" != ghcr.io/* ]]; then
+    echo "REGISTRY must target ghcr.io, got: ${REGISTRY}"
+    exit 1
+fi
+
 for image in ${IMAGES[*]}; do
     tag=${image#*:}
     name=${image%:*}

--- a/hack/image_tag.sh
+++ b/hack/image_tag.sh
@@ -7,9 +7,54 @@ set -o pipefail
 
 OLD_REGISTRY=${OLD_REGISTRY:-}
 REGISTRY=${REGISTRY:-}
-OLD_IMAGES=$(docker images | grep ${OLD_REGISTRY} | grep kube- | grep -v cross | awk '{print $1":"$2}')
-for old_image in ${OLD_IMAGES} ;  do
-    new_image=$(echo ${old_image} | sed "s#${OLD_REGISTRY}#${REGISTRY}#g")
+
+if [[ -z "${REGISTRY}" ]]; then
+    echo "REGISTRY is required"
+    exit 1
+fi
+
+declare -a CANDIDATE_OLD_REGISTRIES=()
+add_candidate_registry() {
+    local candidate="${1}"
+    [[ -z "${candidate}" ]] && return 0
+
+    for existing in "${CANDIDATE_OLD_REGISTRIES[@]}"; do
+        if [[ "${existing}" == "${candidate}" ]]; then
+            return 0
+        fi
+    done
+
+    CANDIDATE_OLD_REGISTRIES+=("${candidate}")
+}
+
+add_candidate_registry "${OLD_REGISTRY}"
+add_candidate_registry "registry.k8s.io"
+add_candidate_registry "k8s.gcr.io"
+
+declare -a OLD_IMAGES=()
+for candidate in "${CANDIDATE_OLD_REGISTRIES[@]}"; do
+    OLD_IMAGES=()
+    while IFS= read -r image; do
+        [[ -n "${image}" ]] && OLD_IMAGES+=("${image}")
+    done < <(
+        docker images --format '{{.Repository}}:{{.Tag}}' \
+            | awk -v prefix="${candidate}/kube-" 'index($0, prefix) == 1 && $0 !~ /cross/ { print $0 }'
+    )
+
+    if [[ ${#OLD_IMAGES[@]} -gt 0 ]]; then
+        OLD_REGISTRY="${candidate}"
+        break
+    fi
+done
+
+if [[ ${#OLD_IMAGES[@]} -eq 0 ]]; then
+    echo "No kube images found under registries: ${CANDIDATE_OLD_REGISTRIES[*]}"
+    exit 0
+fi
+
+echo "Retagging ${#OLD_IMAGES[@]} images from ${OLD_REGISTRY} to ${REGISTRY}"
+for old_image in "${OLD_IMAGES[@]}"; do
+    new_image=$(echo "${old_image}" | sed "s#^${OLD_REGISTRY}#${REGISTRY}#")
     docker tag "${old_image}" "${new_image}"
     docker rmi "${old_image}"
 done

--- a/hack/image_tag.sh
+++ b/hack/image_tag.sh
@@ -13,6 +13,11 @@ if [[ -z "${REGISTRY}" ]]; then
     exit 1
 fi
 
+if [[ "${REGISTRY}" != ghcr.io/* ]]; then
+    echo "REGISTRY must target ghcr.io, got: ${REGISTRY}"
+    exit 1
+fi
+
 declare -a CANDIDATE_OLD_REGISTRIES=()
 add_candidate_registry() {
     local candidate="${1}"


### PR DESCRIPTION
## What
- update `hack/image_tag.sh` to auto-detect old image registry from candidates
- keep current behavior for `registry.k8s.io` and add fallback for legacy `k8s.gcr.io`
- avoid failing when no matching images are found (safe no-op with message)

## Why
Release image workflow currently passes `OLD_REGISTRY=registry.k8s.io`. For older release lines (v1.16-v1.21), built images are tagged under `k8s.gcr.io`, so the old script exits early on empty grep due to `set -e -o pipefail`.

This causes image release jobs to fail at push stage despite successful builds.

## Validation
- bash syntax check: `bash -n hack/image_tag.sh`
- local mocked docker tests:
  - input images under `k8s.gcr.io` are retagged to GHCR
  - input images under `registry.k8s.io` are retagged to GHCR
  - no input images returns success with informative message
