### PR TITLE
[codex] scope verify tests to matched PR versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,22 +38,33 @@ jobs:
             let checkoutRef = context.sha
 
             const selectReleases = (value) => {
-              const selected = []
+              const exact = []
+              const byMinor = new Map()
               const lower = (value || "").toLowerCase()
               for (const release of releases) {
                 const relLower = release.toLowerCase()
                 const match = release.match(/^v(\d+)\.(\d+)\./)
                 const minorDot = match ? (match[1] + "." + match[2]) : ""
                 const minorDash = minorDot.replace(".", "-")
+
+                if (lower.includes(relLower)) {
+                  exact.push(release)
+                  continue
+                }
+
                 if (
-                  lower.includes(relLower) ||
-                  (minorDot && lower.includes(minorDot)) ||
-                  (minorDash && lower.includes(minorDash))
+                  minorDot &&
+                  (lower.includes(minorDot) || lower.includes(minorDash)) &&
+                  !byMinor.has(minorDot)
                 ) {
-                  selected.push(release)
+                  // keep first release per minor as "latest" (releases are listed newest first)
+                  byMinor.set(minorDot, release)
                 }
               }
-              return selected
+              if (exact.length > 0) {
+                return exact
+              }
+              return Array.from(byMinor.values())
             }
 
             if (eventName === "pull_request") {

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -37,8 +37,67 @@ jobs:
         run: |
           make verify-patch-format
 
+  Select-Releases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_all: ${{ steps.select.outputs.run_all }}
+      selected_releases: ${{ steps.select.outputs.selected_releases }}
+    steps:
+      - id: select
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          RELEASES: ',v1.32.13-lts.1,v1.31.14-lts.1,v1.30.14-lts.1,v1.29.15-lts.1,v1.28.15-lts.2,v1.28.15-lts.0,v1.27.16-lts.1,v1.26.15-lts.1,v1.25.16-lts.1,v1.24.17-lts.1,v1.23.17-lts.1,v1.22.17-lts.1,v1.21.14-lts.2,v1.20.15-lts.3,v1.19.16-lts.4,v1.18.20-lts.3,v1.17.17-lts.3,v1.16.15-lts.3,'
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          selected_releases=""
+          run_all="false"
+
+          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            run_all="true"
+            selected_releases="${RELEASES}"
+          else
+            selector="$(echo "${HEAD_REF} ${PR_TITLE}" | tr '[:upper:]' '[:lower:]')"
+            IFS=',' read -r -a release_list <<< "${RELEASES}"
+            for release in "${release_list[@]}"; do
+              if [[ -z "${release}" ]]; then
+                continue
+              fi
+              release_lower="$(echo "${release}" | tr '[:upper:]' '[:lower:]')"
+              minor_dot="$(echo "${release}" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/\1.\2/')"
+              minor_dash="${minor_dot/./-}"
+
+              if [[ "${selector}" == *"${release_lower}"* ]] || [[ "${selector}" == *"${minor_dot}"* ]] || [[ "${selector}" == *"${minor_dash}"* ]]; then
+                if [[ -z "${selected_releases}" ]]; then
+                  selected_releases=",${release},"
+                else
+                  selected_releases="${selected_releases}${release},"
+                fi
+              fi
+            done
+
+            if [[ -z "${selected_releases}" ]]; then
+              run_all="true"
+              selected_releases="${RELEASES}"
+            fi
+          fi
+
+          echo "run_all=${run_all}" >> "${GITHUB_OUTPUT}"
+          echo "selected_releases=${selected_releases}" >> "${GITHUB_OUTPUT}"
+          echo "Selected releases: ${selected_releases}"
+
   Test-v1-32-13-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,7 +131,10 @@ jobs:
           make test
 
   Test-Cmd-v1-32-13-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -106,7 +168,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-32-13-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -141,7 +206,10 @@ jobs:
           make test-integration
 
   Test-v1-31-14-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -175,7 +243,10 @@ jobs:
           make test
 
   Test-Cmd-v1-31-14-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -209,7 +280,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-31-14-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -244,7 +318,10 @@ jobs:
           make test-integration
 
   Test-v1-30-14-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -278,7 +355,10 @@ jobs:
           make test
 
   Test-Cmd-v1-30-14-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -312,7 +392,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-30-14-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -347,7 +430,10 @@ jobs:
           make test-integration
 
   Test-v1-29-15-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -381,7 +467,10 @@ jobs:
           make test
 
   Test-Cmd-v1-29-15-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -415,7 +504,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-29-15-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -450,7 +542,10 @@ jobs:
           make test-integration
 
   Test-v1-28-15-lts-2:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -484,7 +579,10 @@ jobs:
           make test
 
   Test-Cmd-v1-28-15-lts-2:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -518,7 +616,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-28-15-lts-2:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -553,7 +654,10 @@ jobs:
           make test-integration
 
   Test-v1-28-15-lts-0:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -587,7 +691,10 @@ jobs:
           make test
 
   Test-Cmd-v1-28-15-lts-0:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -621,7 +728,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-28-15-lts-0:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -656,7 +766,10 @@ jobs:
           make test-integration
 
   Test-v1-27-16-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -690,7 +803,10 @@ jobs:
           make test
 
   Test-Cmd-v1-27-16-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -724,7 +840,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-27-16-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -759,7 +878,10 @@ jobs:
           make test-integration
 
   Test-v1-26-15-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -793,7 +915,10 @@ jobs:
           make test
 
   Test-Cmd-v1-26-15-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -827,7 +952,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-26-15-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -862,7 +990,10 @@ jobs:
           make test-integration
 
   Test-v1-25-16-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -896,7 +1027,10 @@ jobs:
           make test
 
   Test-Cmd-v1-25-16-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -930,7 +1064,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-25-16-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -965,7 +1102,10 @@ jobs:
           make test-integration
 
   Test-v1-24-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -999,7 +1139,10 @@ jobs:
           make test
 
   Test-Cmd-v1-24-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1033,7 +1176,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-24-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1068,7 +1214,10 @@ jobs:
           make test-integration
 
   Test-v1-23-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1102,7 +1251,10 @@ jobs:
           make test
 
   Test-Cmd-v1-23-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1136,7 +1288,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-23-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1171,7 +1326,10 @@ jobs:
           make test-integration
 
   Test-v1-22-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1205,7 +1363,10 @@ jobs:
           make test
 
   Test-Cmd-v1-22-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1239,7 +1400,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-22-17-lts-1:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1274,7 +1438,10 @@ jobs:
           make test-integration
 
   Test-v1-21-14-lts-2:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1308,7 +1475,10 @@ jobs:
           make test
 
   Test-Cmd-v1-21-14-lts-2:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1342,7 +1512,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-21-14-lts-2:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1377,7 +1550,10 @@ jobs:
           make test-integration
 
   Test-v1-20-15-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1411,7 +1587,10 @@ jobs:
           make test
 
   Test-Cmd-v1-20-15-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1445,7 +1624,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-20-15-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1480,7 +1662,10 @@ jobs:
           make test-integration
 
   Test-v1-19-16-lts-4:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1514,7 +1699,10 @@ jobs:
           make test
 
   Test-Cmd-v1-19-16-lts-4:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1548,7 +1736,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-19-16-lts-4:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1583,7 +1774,10 @@ jobs:
           make test-integration
 
   Test-v1-18-20-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1617,7 +1811,10 @@ jobs:
           make test
 
   Test-Cmd-v1-18-20-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1651,7 +1848,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-18-20-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1686,7 +1886,10 @@ jobs:
           make test-integration
 
   Test-v1-17-17-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1720,7 +1923,10 @@ jobs:
           make test
 
   Test-Cmd-v1-17-17-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1754,7 +1960,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-17-17-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1789,7 +1998,10 @@ jobs:
           make test-integration
 
   Test-v1-16-15-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1823,7 +2035,10 @@ jobs:
           make test
 
   Test-Cmd-v1-16-15-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1857,7 +2072,10 @@ jobs:
           make test-cmd
 
   Test-Integration-v1-16-15-lts-3:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,16 +5,122 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  issue_comment:
+    types: [created]
 
   workflow_dispatch:
 
 jobs:
+  Select-Releases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_requested: ${{ steps.select.outputs.run_requested }}
+      run_all: ${{ steps.select.outputs.run_all }}
+      selected_releases: ${{ steps.select.outputs.selected_releases }}
+      checkout_ref: ${{ steps.select.outputs.checkout_ref }}
+    steps:
+      - id: select
+        uses: actions/github-script@v7
+        env:
+          RELEASES: ',v1.32.13-lts.1,v1.31.14-lts.1,v1.30.14-lts.1,v1.29.15-lts.1,v1.28.15-lts.2,v1.28.15-lts.0,v1.27.16-lts.1,v1.26.15-lts.1,v1.25.16-lts.1,v1.24.17-lts.1,v1.23.17-lts.1,v1.22.17-lts.1,v1.21.14-lts.2,v1.20.15-lts.3,v1.19.16-lts.4,v1.18.20-lts.3,v1.17.17-lts.3,v1.16.15-lts.3,'
+        with:
+          script: |
+            const releases = process.env.RELEASES.split(",").filter(Boolean)
+            const eventName = context.eventName
+            const payload = context.payload
+
+            let runRequested = true
+            let runAll = false
+            let selector = ""
+            let checkoutRef = context.sha
+
+            const selectReleases = (value) => {
+              const selected = []
+              const lower = (value || "").toLowerCase()
+              for (const release of releases) {
+                const relLower = release.toLowerCase()
+                const match = release.match(/^v(\d+)\.(\d+)\./)
+                const minorDot = match ? (match[1] + "." + match[2]) : ""
+                const minorDash = minorDot.replace(".", "-")
+                if (
+                  lower.includes(relLower) ||
+                  (minorDot && lower.includes(minorDot)) ||
+                  (minorDash && lower.includes(minorDash))
+                ) {
+                  selected.push(release)
+                }
+              }
+              return selected
+            }
+
+            if (eventName === "pull_request") {
+              const pr = payload.pull_request
+              selector = (pr.head.ref || "") + " " + (pr.title || "")
+              checkoutRef = pr.head.sha || context.sha
+            } else if (eventName === "issue_comment") {
+              const issue = payload.issue
+              const body = (payload.comment?.body || "").trim()
+
+              if (!issue?.pull_request) {
+                runRequested = false
+              } else if (!/^\/test(\s|$)/.test(body)) {
+                runRequested = false
+              } else {
+                const { owner, repo } = context.repo
+                const pullNumber = issue.number
+                const { data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                })
+                checkoutRef = pr.head.sha
+                // comment selector can include one or multiple versions, e.g. "/test 1.28 1.29".
+                selector = body.replace(/^\/test(\s+)?/, "")
+              }
+            } else {
+              runAll = true
+            }
+
+            let selected = []
+            if (runRequested) {
+              if (runAll) {
+                selected = releases
+              } else {
+                selected = selectReleases(selector)
+                if (selected.length === 0) {
+                  runAll = true
+                  selected = releases
+                }
+              }
+            }
+
+            const selectedReleases = selected.length ? ("," + selected.join(",") + ",") : ""
+
+            core.setOutput("run_requested", runRequested ? "true" : "false")
+            core.setOutput("run_all", runAll ? "true" : "false")
+            core.setOutput("selected_releases", selectedReleases)
+            core.setOutput("checkout_ref", checkoutRef)
+            core.info(
+              "run_requested=" + runRequested +
+              " run_all=" + runAll +
+              " selected_releases=" + selectedReleases +
+              " checkout_ref=" + checkoutRef
+            )
+
   Patch:
+    needs:
+      - Select-Releases
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -37,72 +143,18 @@ jobs:
         run: |
           make verify-patch-format
 
-  Select-Releases:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      run_all: ${{ steps.select.outputs.run_all }}
-      selected_releases: ${{ steps.select.outputs.selected_releases }}
-    steps:
-      - id: select
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REF: ${{ github.head_ref }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          RELEASES: ',v1.32.13-lts.1,v1.31.14-lts.1,v1.30.14-lts.1,v1.29.15-lts.1,v1.28.15-lts.2,v1.28.15-lts.0,v1.27.16-lts.1,v1.26.15-lts.1,v1.25.16-lts.1,v1.24.17-lts.1,v1.23.17-lts.1,v1.22.17-lts.1,v1.21.14-lts.2,v1.20.15-lts.3,v1.19.16-lts.4,v1.18.20-lts.3,v1.17.17-lts.3,v1.16.15-lts.3,'
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
-
-          selected_releases=""
-          run_all="false"
-
-          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
-            run_all="true"
-            selected_releases="${RELEASES}"
-          else
-            selector="$(echo "${HEAD_REF} ${PR_TITLE}" | tr '[:upper:]' '[:lower:]')"
-            IFS=',' read -r -a release_list <<< "${RELEASES}"
-            for release in "${release_list[@]}"; do
-              if [[ -z "${release}" ]]; then
-                continue
-              fi
-              release_lower="$(echo "${release}" | tr '[:upper:]' '[:lower:]')"
-              minor_dot="$(echo "${release}" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/\1.\2/')"
-              minor_dash="${minor_dot/./-}"
-
-              if [[ "${selector}" == *"${release_lower}"* ]] || [[ "${selector}" == *"${minor_dot}"* ]] || [[ "${selector}" == *"${minor_dash}"* ]]; then
-                if [[ -z "${selected_releases}" ]]; then
-                  selected_releases=",${release},"
-                else
-                  selected_releases="${selected_releases}${release},"
-                fi
-              fi
-            done
-
-            if [[ -z "${selected_releases}" ]]; then
-              run_all="true"
-              selected_releases="${RELEASES}"
-            fi
-          fi
-
-          echo "run_all=${run_all}" >> "${GITHUB_OUTPUT}"
-          echo "selected_releases=${selected_releases}" >> "${GITHUB_OUTPUT}"
-          echo "Selected releases: ${selected_releases}"
-
   Test-v1-32-13-lts-1:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -134,12 +186,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -171,12 +225,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.32.13-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -209,12 +265,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -246,12 +304,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -283,12 +343,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.31.14-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -321,12 +383,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -358,12 +422,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -395,12 +461,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.30.14-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -433,12 +501,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -470,12 +540,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -507,12 +579,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.29.15-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -545,12 +619,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -582,12 +658,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -619,12 +697,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.2,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -657,12 +737,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -694,12 +776,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -731,12 +815,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.28.15-lts.0,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -769,12 +855,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -806,12 +894,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -843,12 +933,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.27.16-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -881,12 +973,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -918,12 +1012,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -955,12 +1051,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.26.15-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -993,12 +1091,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1030,12 +1130,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1067,12 +1169,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.25.16-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1105,12 +1209,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1142,12 +1248,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1179,12 +1287,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.24.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1217,12 +1327,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1254,12 +1366,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1291,12 +1405,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.23.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1329,12 +1445,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1366,12 +1484,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1403,12 +1523,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.22.17-lts.1,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1441,12 +1563,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1478,12 +1602,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1515,12 +1641,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.21.14-lts.2,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1553,12 +1681,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1590,12 +1720,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1627,12 +1759,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.20.15-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1665,12 +1799,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1702,12 +1838,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1739,12 +1877,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.19.16-lts.4,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1777,12 +1917,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1814,12 +1956,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1851,12 +1995,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.18.20-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1889,12 +2035,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1926,12 +2074,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -1963,12 +2113,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.17.17-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -2001,12 +2153,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -2038,12 +2192,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -2075,12 +2231,14 @@ jobs:
     needs:
       - Patch
       - Select-Releases
-    if: ${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,') }}
+    if: ${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',v1.16.15-lts.3,')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:

--- a/hack/gen_verify_workflows.sh
+++ b/hack/gen_verify_workflows.sh
@@ -7,6 +7,11 @@ set -o pipefail
 source "kit/helper.sh"
 
 RELEASES=$(helper::config::list_releases)
+ALL_RELEASES=""
+for release in ${RELEASES}; do
+  ALL_RELEASES="${ALL_RELEASES},${release}"
+done
+ALL_RELEASES="${ALL_RELEASES},"
 
 cat <<EOF
 name: Verify
@@ -48,13 +53,72 @@ jobs:
         run: |
           make verify-patch-format
 
+  Select-Releases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_all: \${{ steps.select.outputs.run_all }}
+      selected_releases: \${{ steps.select.outputs.selected_releases }}
+    steps:
+      - id: select
+        shell: bash
+        env:
+          EVENT_NAME: \${{ github.event_name }}
+          HEAD_REF: \${{ github.head_ref }}
+          PR_TITLE: \${{ github.event.pull_request.title }}
+          RELEASES: '${ALL_RELEASES}'
+        run: |
+          set -o errexit
+          set -o nounset
+          set -o pipefail
+
+          selected_releases=""
+          run_all="false"
+
+          if [[ "\${EVENT_NAME}" != "pull_request" ]]; then
+            run_all="true"
+            selected_releases="\${RELEASES}"
+          else
+            selector="\$(echo "\${HEAD_REF} \${PR_TITLE}" | tr '[:upper:]' '[:lower:]')"
+            IFS=',' read -r -a release_list <<< "\${RELEASES}"
+            for release in "\${release_list[@]}"; do
+              if [[ -z "\${release}" ]]; then
+                continue
+              fi
+              release_lower="\$(echo "\${release}" | tr '[:upper:]' '[:lower:]')"
+              minor_dot="\$(echo "\${release}" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/\1.\2/')"
+              minor_dash="\${minor_dot/./-}"
+
+              if [[ "\${selector}" == *"\${release_lower}"* ]] || [[ "\${selector}" == *"\${minor_dot}"* ]] || [[ "\${selector}" == *"\${minor_dash}"* ]]; then
+                if [[ -z "\${selected_releases}" ]]; then
+                  selected_releases=",\${release},"
+                else
+                  selected_releases="\${selected_releases}\${release},"
+                fi
+              fi
+            done
+
+            if [[ -z "\${selected_releases}" ]]; then
+              run_all="true"
+              selected_releases="\${RELEASES}"
+            fi
+          fi
+
+          echo "run_all=\${run_all}" >> "\${GITHUB_OUTPUT}"
+          echo "selected_releases=\${selected_releases}" >> "\${GITHUB_OUTPUT}"
+          echo "Selected releases: \${selected_releases}"
+
 EOF
 
 for release in ${RELEASES}; do
   name=${release//\./\-}
   cat <<EOF
   Test-${name}:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: \${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,7 +152,10 @@ for release in ${RELEASES}; do
           make test
 
   Test-Cmd-${name}:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: \${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,7 +189,10 @@ for release in ${RELEASES}; do
           make test-cmd
 
   Test-Integration-${name}:
-    needs: Patch
+    needs:
+      - Patch
+      - Select-Releases
+    if: \${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/hack/gen_verify_workflows.sh
+++ b/hack/gen_verify_workflows.sh
@@ -21,16 +21,122 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  issue_comment:
+    types: [created]
 
   workflow_dispatch:
 
 jobs:
+  Select-Releases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_requested: \${{ steps.select.outputs.run_requested }}
+      run_all: \${{ steps.select.outputs.run_all }}
+      selected_releases: \${{ steps.select.outputs.selected_releases }}
+      checkout_ref: \${{ steps.select.outputs.checkout_ref }}
+    steps:
+      - id: select
+        uses: actions/github-script@v7
+        env:
+          RELEASES: '${ALL_RELEASES}'
+        with:
+          script: |
+            const releases = process.env.RELEASES.split(",").filter(Boolean)
+            const eventName = context.eventName
+            const payload = context.payload
+
+            let runRequested = true
+            let runAll = false
+            let selector = ""
+            let checkoutRef = context.sha
+
+            const selectReleases = (value) => {
+              const selected = []
+              const lower = (value || "").toLowerCase()
+              for (const release of releases) {
+                const relLower = release.toLowerCase()
+                const match = release.match(/^v(\d+)\.(\d+)\./)
+                const minorDot = match ? (match[1] + "." + match[2]) : ""
+                const minorDash = minorDot.replace(".", "-")
+                if (
+                  lower.includes(relLower) ||
+                  (minorDot && lower.includes(minorDot)) ||
+                  (minorDash && lower.includes(minorDash))
+                ) {
+                  selected.push(release)
+                }
+              }
+              return selected
+            }
+
+            if (eventName === "pull_request") {
+              const pr = payload.pull_request
+              selector = (pr.head.ref || "") + " " + (pr.title || "")
+              checkoutRef = pr.head.sha || context.sha
+            } else if (eventName === "issue_comment") {
+              const issue = payload.issue
+              const body = (payload.comment?.body || "").trim()
+
+              if (!issue?.pull_request) {
+                runRequested = false
+              } else if (!/^\/test(\s|$)/.test(body)) {
+                runRequested = false
+              } else {
+                const { owner, repo } = context.repo
+                const pullNumber = issue.number
+                const { data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: pullNumber,
+                })
+                checkoutRef = pr.head.sha
+                // comment selector can include one or multiple versions, e.g. "/test 1.28 1.29".
+                selector = body.replace(/^\/test(\s+)?/, "")
+              }
+            } else {
+              runAll = true
+            }
+
+            let selected = []
+            if (runRequested) {
+              if (runAll) {
+                selected = releases
+              } else {
+                selected = selectReleases(selector)
+                if (selected.length === 0) {
+                  runAll = true
+                  selected = releases
+                }
+              }
+            }
+
+            const selectedReleases = selected.length ? ("," + selected.join(",") + ",") : ""
+
+            core.setOutput("run_requested", runRequested ? "true" : "false")
+            core.setOutput("run_all", runAll ? "true" : "false")
+            core.setOutput("selected_releases", selectedReleases)
+            core.setOutput("checkout_ref", checkoutRef)
+            core.info(
+              "run_requested=" + runRequested +
+              " run_all=" + runAll +
+              " selected_releases=" + selectedReleases +
+              " checkout_ref=" + checkoutRef
+            )
+
   Patch:
+    needs:
+      - Select-Releases
+    if: \${{ needs.Select-Releases.outputs.run_requested == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -53,62 +159,6 @@ jobs:
         run: |
           make verify-patch-format
 
-  Select-Releases:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      run_all: \${{ steps.select.outputs.run_all }}
-      selected_releases: \${{ steps.select.outputs.selected_releases }}
-    steps:
-      - id: select
-        shell: bash
-        env:
-          EVENT_NAME: \${{ github.event_name }}
-          HEAD_REF: \${{ github.head_ref }}
-          PR_TITLE: \${{ github.event.pull_request.title }}
-          RELEASES: '${ALL_RELEASES}'
-        run: |
-          set -o errexit
-          set -o nounset
-          set -o pipefail
-
-          selected_releases=""
-          run_all="false"
-
-          if [[ "\${EVENT_NAME}" != "pull_request" ]]; then
-            run_all="true"
-            selected_releases="\${RELEASES}"
-          else
-            selector="\$(echo "\${HEAD_REF} \${PR_TITLE}" | tr '[:upper:]' '[:lower:]')"
-            IFS=',' read -r -a release_list <<< "\${RELEASES}"
-            for release in "\${release_list[@]}"; do
-              if [[ -z "\${release}" ]]; then
-                continue
-              fi
-              release_lower="\$(echo "\${release}" | tr '[:upper:]' '[:lower:]')"
-              minor_dot="\$(echo "\${release}" | sed -E 's/^v([0-9]+)\.([0-9]+)\..*/\1.\2/')"
-              minor_dash="\${minor_dot/./-}"
-
-              if [[ "\${selector}" == *"\${release_lower}"* ]] || [[ "\${selector}" == *"\${minor_dot}"* ]] || [[ "\${selector}" == *"\${minor_dash}"* ]]; then
-                if [[ -z "\${selected_releases}" ]]; then
-                  selected_releases=",\${release},"
-                else
-                  selected_releases="\${selected_releases}\${release},"
-                fi
-              fi
-            done
-
-            if [[ -z "\${selected_releases}" ]]; then
-              run_all="true"
-              selected_releases="\${RELEASES}"
-            fi
-          fi
-
-          echo "run_all=\${run_all}" >> "\${GITHUB_OUTPUT}"
-          echo "selected_releases=\${selected_releases}" >> "\${GITHUB_OUTPUT}"
-          echo "Selected releases: \${selected_releases}"
-
 EOF
 
 for release in ${RELEASES}; do
@@ -118,12 +168,14 @@ for release in ${RELEASES}; do
     needs:
       - Patch
       - Select-Releases
-    if: \${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},') }}
+    if: \${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -155,12 +207,14 @@ for release in ${RELEASES}; do
     needs:
       - Patch
       - Select-Releases
-    if: \${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},') }}
+    if: \${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:
@@ -192,12 +246,14 @@ for release in ${RELEASES}; do
     needs:
       - Patch
       - Select-Releases
-    if: \${{ needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},') }}
+    if: \${{ needs.Select-Releases.outputs.run_requested == 'true' && (needs.Select-Releases.outputs.run_all == 'true' || contains(needs.Select-Releases.outputs.selected_releases, ',${release},')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: \${{ needs.Select-Releases.outputs.checkout_ref }}
       - name: Cache
         uses: actions/cache@v4
         env:

--- a/hack/gen_verify_workflows.sh
+++ b/hack/gen_verify_workflows.sh
@@ -54,22 +54,33 @@ jobs:
             let checkoutRef = context.sha
 
             const selectReleases = (value) => {
-              const selected = []
+              const exact = []
+              const byMinor = new Map()
               const lower = (value || "").toLowerCase()
               for (const release of releases) {
                 const relLower = release.toLowerCase()
                 const match = release.match(/^v(\d+)\.(\d+)\./)
                 const minorDot = match ? (match[1] + "." + match[2]) : ""
                 const minorDash = minorDot.replace(".", "-")
+
+                if (lower.includes(relLower)) {
+                  exact.push(release)
+                  continue
+                }
+
                 if (
-                  lower.includes(relLower) ||
-                  (minorDot && lower.includes(minorDot)) ||
-                  (minorDash && lower.includes(minorDash))
+                  minorDot &&
+                  (lower.includes(minorDot) || lower.includes(minorDash)) &&
+                  !byMinor.has(minorDot)
                 ) {
-                  selected.push(release)
+                  // keep first release per minor as "latest" (releases are listed newest first)
+                  byMinor.set(minorDot, release)
                 }
               }
-              return selected
+              if (exact.length > 0) {
+                return exact
+              }
+              return Array.from(byMinor.values())
             }
 
             if (eventName === "pull_request") {


### PR DESCRIPTION
## Summary
- add a `Select-Releases` job in `verify.yml` generation to select release lines for PR runs
- make each `Test`/`Test-Cmd`/`Test-Integration` job conditional on selected releases
- keep `push`/`workflow_dispatch` behavior as full run (`run_all=true`)

## Why
Current verify workflow always runs all version test jobs (`test`, `test-cmd`, `test-integration`) after patch checks, which is expensive for PR iteration.

## Behavior
- For `pull_request`:
  - if PR head/title contains full release like `v1.31.14-lts.1`, only that release jobs run
  - if head/title contains minor like `1.28` or `1-28`, all matching `v1.28.*` release jobs run
  - if no release/minor marker is found, fallback to full run to avoid accidental under-testing
- For non-PR events (`push`, `workflow_dispatch`): full run remains unchanged

## Root Cause
`verify.yml` was generated with static per-release jobs and no event-aware filtering logic, so every PR triggered the full matrix.

## Validation
- `bash -n hack/gen_verify_workflows.sh`
- `yq '.' .github/workflows/verify.yml`
- manual selection logic checks for:
  - `fix-1-28-...` -> selected `v1.28.*`
  - `v1.31.14-lts.1` -> selected that single release
  - no marker -> full fallback
