### PR TITLE
build: bump Go to 1.25.9 for release-1.24 release-1.25 release-1.26 release-1.27 release-1.28

### DIFF
--- a/patches/bump-go-1-25-9.1.25.patch
+++ b/patches/bump-go-1-25-9.1.25.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] build: bump Go to 1.25.9 for release-1.25
  6 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/.go-version b/.go-version
-index acdfc79..9b9ebce 100644
+index acdfc7930c8..9b9ebced0e9 100644
 --- a/.go-version
 +++ b/.go-version
 @@ -1 +1 @@
@@ -21,14 +21,14 @@ index acdfc79..9b9ebce 100644
 +1.25.9
 \ No newline at end of file
 diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
-index 074c0cc..306a07c 100644
+index 074c0ccf0c6..306a07c99c8 100644
 --- a/build/build-image/cross/VERSION
 +++ b/build/build-image/cross/VERSION
 @@ -1 +1 @@
 -v1.25.0-go1.20.10-bullseye.0
 +v1.33.0-go1.25.9-bullseye.0
 diff --git a/build/common.sh b/build/common.sh
-index 5d6bc6f..3f9b0d8 100644
+index ea4ceb3ec94..51c012924d3 100755
 --- a/build/common.sh
 +++ b/build/common.sh
 @@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
@@ -41,7 +41,7 @@ index 5d6bc6f..3f9b0d8 100644
  
  # These are the base images for the Docker-wrapped binaries.
 diff --git a/build/dependencies.yaml b/build/dependencies.yaml
-index e3a55f7..0c68523 100644
+index e3a55f7bd31..0c685233577 100644
 --- a/build/dependencies.yaml
 +++ b/build/dependencies.yaml
 @@ -88,7 +88,7 @@ dependencies:
@@ -72,7 +72,7 @@ index e3a55f7..0c68523 100644
      - path: build/common.sh
        match: __default_go_runner_version=
 diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
-index 2aa6dac..178f225 100644
+index 2aa6dace43d..178f2258000 100644
 --- a/staging/publishing/rules.yaml
 +++ b/staging/publishing/rules.yaml
 @@ -1974,4 +1974,4 @@ recursive-delete-patterns:
@@ -82,7 +82,7 @@ index 2aa6dac..178f225 100644
 -default-go-version: 1.20.10
 +default-go-version: 1.25.9
 diff --git a/test/images/Makefile b/test/images/Makefile
-index ebd6ffd..26d4d35 100644
+index ebd6ffd0ff0..26d4d3546b1 100644
 --- a/test/images/Makefile
 +++ b/test/images/Makefile
 @@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images

--- a/patches/bump-go-1-25-9.1.25.patch
+++ b/patches/bump-go-1-25-9.1.25.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Wed, 15 Apr 2026 17:29:10 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.25
+
+---
+ .go-version                     | 2 +-
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 6 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/.go-version b/.go-version
+index acdfc79..9b9ebce 100644
+--- a/.go-version
++++ b/.go-version
+@@ -1 +1 @@
+-1.20.10
++1.25.9
+\ No newline at end of file
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index 074c0cc..306a07c 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.25.0-go1.20.10-bullseye.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 5d6bc6f..3f9b0d8 100644
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_distroless_iptables_version=v0.1.1
+-readonly __default_go_runner_version=v2.3.1-go1.20.10-bullseye.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=bullseye-v1.3.0
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index e3a55f7..0c68523 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -88,7 +88,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.20.10
++    version: 1.25.9
+     refPaths:
+     - path: .go-version
+     - path: build/build-image/cross/VERSION
+@@ -112,7 +112,7 @@ dependencies:
+     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "registry.k8s.io/kube-cross: dependents"
+-    version: v1.25.0-go1.20.10-bullseye.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -142,7 +142,7 @@ dependencies:
+       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
+ 
+   - name: "registry.k8s.io/go-runner: dependents"
+-    version: v2.3.1-go1.20.10-bullseye.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 2aa6dac..178f225 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -1974,4 +1974,4 @@ recursive-delete-patterns:
+ - '*/BUILD.bazel'
+ - Gopkg.toml
+ - '*/.gitattributes'
+-default-go-version: 1.20.10
++default-go-version: 1.25.9
+diff --git a/test/images/Makefile b/test/images/Makefile
+index ebd6ffd..26d4d35 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.20.10
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/patches/bump-go-1-25-9.1.26.patch
+++ b/patches/bump-go-1-25-9.1.26.patch
@@ -1,0 +1,97 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Wed, 15 Apr 2026 17:29:17 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.26
+
+---
+ .go-version                     | 2 +-
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 6 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/.go-version b/.go-version
+index 5c9a6fe..9b9ebce 100644
+--- a/.go-version
++++ b/.go-version
+@@ -1 +1 @@
+-1.21.8
+\ No newline at end of file
++1.25.9
+\ No newline at end of file
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index ef8ee48..306a07c 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.26.0-go1.21.8-bullseye.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 627f0b5..80e4a6d 100644
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -96,7 +96,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_distroless_iptables_version=v0.4.6
+-readonly __default_go_runner_version=v2.3.1-go1.21.8-bullseye.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=bullseye-v1.3.0
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index 09dc34a..cfbf931 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -88,7 +88,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.21.8
++    version: 1.25.9
+     refPaths:
+     - path: .go-version
+     - path: build/build-image/cross/VERSION
+@@ -112,7 +112,7 @@ dependencies:
+     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "registry.k8s.io/kube-cross: dependents"
+-    version: v1.26.0-go1.21.8-bullseye.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -142,7 +142,7 @@ dependencies:
+       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
+ 
+   - name: "registry.k8s.io/go-runner: dependents"
+-    version: v2.3.1-go1.21.8-bullseye.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 1a41026..d67f981 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -2432,4 +2432,4 @@ rules:
+       dir: staging/src/k8s.io/dynamic-resource-allocation
+ recursive-delete-patterns:
+ - '*/.gitattributes'
+-default-go-version: 1.21.8
++default-go-version: 1.25.9
+diff --git a/test/images/Makefile b/test/images/Makefile
+index 769be9c..26d4d35 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.21.8
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/patches/bump-go-1-25-9.1.26.patch
+++ b/patches/bump-go-1-25-9.1.26.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] build: bump Go to 1.25.9 for release-1.26
  6 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/.go-version b/.go-version
-index 5c9a6fe..9b9ebce 100644
+index 5c9a6fe71a5..9b9ebced0e9 100644
 --- a/.go-version
 +++ b/.go-version
 @@ -1 +1 @@
@@ -22,14 +22,14 @@ index 5c9a6fe..9b9ebce 100644
 +1.25.9
 \ No newline at end of file
 diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
-index ef8ee48..306a07c 100644
+index ef8ee482c4d..306a07c99c8 100644
 --- a/build/build-image/cross/VERSION
 +++ b/build/build-image/cross/VERSION
 @@ -1 +1 @@
 -v1.26.0-go1.21.8-bullseye.0
 +v1.33.0-go1.25.9-bullseye.0
 diff --git a/build/common.sh b/build/common.sh
-index 627f0b5..80e4a6d 100644
+index 92a8ea7b1cc..2d238f9d41f 100755
 --- a/build/common.sh
 +++ b/build/common.sh
 @@ -96,7 +96,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
@@ -42,7 +42,7 @@ index 627f0b5..80e4a6d 100644
  
  # These are the base images for the Docker-wrapped binaries.
 diff --git a/build/dependencies.yaml b/build/dependencies.yaml
-index 09dc34a..cfbf931 100644
+index 09dc34a3ed8..cfbf9314ff7 100644
 --- a/build/dependencies.yaml
 +++ b/build/dependencies.yaml
 @@ -88,7 +88,7 @@ dependencies:
@@ -73,7 +73,7 @@ index 09dc34a..cfbf931 100644
      - path: build/common.sh
        match: __default_go_runner_version=
 diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
-index 1a41026..d67f981 100644
+index 1a410260915..d67f981b780 100644
 --- a/staging/publishing/rules.yaml
 +++ b/staging/publishing/rules.yaml
 @@ -2432,4 +2432,4 @@ rules:
@@ -83,7 +83,7 @@ index 1a41026..d67f981 100644
 -default-go-version: 1.21.8
 +default-go-version: 1.25.9
 diff --git a/test/images/Makefile b/test/images/Makefile
-index 769be9c..26d4d35 100644
+index 769be9c7c86..26d4d3546b1 100644
 --- a/test/images/Makefile
 +++ b/test/images/Makefile
 @@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images

--- a/patches/bump-go-1-25-9.1.27.patch
+++ b/patches/bump-go-1-25-9.1.27.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] build: bump Go to 1.25.9 for release-1.27
  6 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/.go-version b/.go-version
-index 054c858..9b9ebce 100644
+index 054c858fbf3..9b9ebced0e9 100644
 --- a/.go-version
 +++ b/.go-version
 @@ -1 +1 @@
@@ -22,14 +22,14 @@ index 054c858..9b9ebce 100644
 +1.25.9
 \ No newline at end of file
 diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
-index 48c90f2..306a07c 100644
+index 48c90f22660..306a07c99c8 100644
 --- a/build/build-image/cross/VERSION
 +++ b/build/build-image/cross/VERSION
 @@ -1 +1 @@
 -v1.27.0-go1.22.5-bullseye.0
 +v1.33.0-go1.25.9-bullseye.0
 diff --git a/build/common.sh b/build/common.sh
-index 83878cb..f9b51b6 100644
+index 83878cb7cfc..f9b51b6c599 100755
 --- a/build/common.sh
 +++ b/build/common.sh
 @@ -96,7 +96,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
@@ -42,7 +42,7 @@ index 83878cb..f9b51b6 100644
  
  # These are the base images for the Docker-wrapped binaries.
 diff --git a/build/dependencies.yaml b/build/dependencies.yaml
-index 82e2f7c..851745d 100644
+index 82e2f7ca4e2..851745defa3 100644
 --- a/build/dependencies.yaml
 +++ b/build/dependencies.yaml
 @@ -95,7 +95,7 @@ dependencies:
@@ -73,7 +73,7 @@ index 82e2f7c..851745d 100644
      - path: build/common.sh
        match: __default_go_runner_version=
 diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
-index 78e364f..f4bf915 100644
+index 78e364f1353..f4bf91511e5 100644
 --- a/staging/publishing/rules.yaml
 +++ b/staging/publishing/rules.yaml
 @@ -2095,4 +2095,4 @@ rules:
@@ -85,7 +85,7 @@ index 78e364f..f4bf915 100644
 +default-go-version: 1.25.9
 \ No newline at end of file
 diff --git a/test/images/Makefile b/test/images/Makefile
-index 56bbb67..26d4d35 100644
+index 56bbb67fd63..26d4d3546b1 100644
 --- a/test/images/Makefile
 +++ b/test/images/Makefile
 @@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images

--- a/patches/bump-go-1-25-9.1.27.patch
+++ b/patches/bump-go-1-25-9.1.27.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Wed, 15 Apr 2026 17:29:24 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.27
+
+---
+ .go-version                     | 2 +-
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 6 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/.go-version b/.go-version
+index 054c858..9b9ebce 100644
+--- a/.go-version
++++ b/.go-version
+@@ -1 +1 @@
+-1.22.5
+\ No newline at end of file
++1.25.9
+\ No newline at end of file
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index 48c90f2..306a07c 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.27.0-go1.22.5-bullseye.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 83878cb..f9b51b6 100644
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -96,7 +96,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_distroless_iptables_version=v0.5.6
+-readonly __default_go_runner_version=v2.3.1-go1.22.5-bookworm.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=bullseye-v1.4.2
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index 82e2f7c..851745d 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -95,7 +95,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.22.5
++    version: 1.25.9
+     refPaths:
+     - path: .go-version
+     - path: build/build-image/cross/VERSION
+@@ -118,7 +118,7 @@ dependencies:
+     #   match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "registry.k8s.io/kube-cross: dependents"
+-    version: v1.27.0-go1.22.5-bullseye.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -148,7 +148,7 @@ dependencies:
+       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
+ 
+   - name: "registry.k8s.io/go-runner: dependents"
+-    version: v2.3.1-go1.22.5-bookworm.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 78e364f..f4bf915 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -2095,4 +2095,4 @@ rules:
+       dir: staging/src/k8s.io/dynamic-resource-allocation
+ recursive-delete-patterns:
+ - '*/.gitattributes'
+-default-go-version: 1.22.5
+\ No newline at end of file
++default-go-version: 1.25.9
+\ No newline at end of file
+diff --git a/test/images/Makefile b/test/images/Makefile
+index 56bbb67..26d4d35 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.22.5
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/patches/bump-go-1-25-9.1.28.patch
+++ b/patches/bump-go-1-25-9.1.28.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] build: bump Go to 1.25.9 for release-1.28
  6 files changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/.go-version b/.go-version
-index 0793194..9b9ebce 100644
+index 0793194ffc1..9b9ebced0e9 100644
 --- a/.go-version
 +++ b/.go-version
 @@ -1 +1 @@
@@ -22,14 +22,14 @@ index 0793194..9b9ebce 100644
 +1.25.9
 \ No newline at end of file
 diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
-index 6a30a4d..306a07c 100644
+index 6a30a4d5d3f..306a07c99c8 100644
 --- a/build/build-image/cross/VERSION
 +++ b/build/build-image/cross/VERSION
 @@ -1 +1 @@
 -v1.28.0-go1.22.8-bullseye.0
 +v1.33.0-go1.25.9-bullseye.0
 diff --git a/build/common.sh b/build/common.sh
-index 8328a46..04805c8 100644
+index 8328a460873..04805c891a2 100755
 --- a/build/common.sh
 +++ b/build/common.sh
 @@ -97,7 +97,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
@@ -42,7 +42,7 @@ index 8328a46..04805c8 100644
  
  # These are the base images for the Docker-wrapped binaries.
 diff --git a/build/dependencies.yaml b/build/dependencies.yaml
-index 4da1f08..d6c68d7 100644
+index 4da1f08e188..d6c68d78425 100644
 --- a/build/dependencies.yaml
 +++ b/build/dependencies.yaml
 @@ -114,7 +114,7 @@ dependencies:
@@ -73,7 +73,7 @@ index 4da1f08..d6c68d7 100644
      - path: build/common.sh
        match: __default_go_runner_version=
 diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
-index 1346086..f0584c1 100644
+index 13460867f24..f0584c1aa0d 100644
 --- a/staging/publishing/rules.yaml
 +++ b/staging/publishing/rules.yaml
 @@ -2570,4 +2570,4 @@ rules:
@@ -83,7 +83,7 @@ index 1346086..f0584c1 100644
 -default-go-version: 1.22.8
 +default-go-version: 1.25.9
 diff --git a/test/images/Makefile b/test/images/Makefile
-index dfeec97..26d4d35 100644
+index dfeec973f79..26d4d3546b1 100644
 --- a/test/images/Makefile
 +++ b/test/images/Makefile
 @@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images

--- a/patches/bump-go-1-25-9.1.28.patch
+++ b/patches/bump-go-1-25-9.1.28.patch
@@ -1,0 +1,97 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Wed, 15 Apr 2026 17:29:29 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.28
+
+---
+ .go-version                     | 2 +-
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 6 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/.go-version b/.go-version
+index 0793194..9b9ebce 100644
+--- a/.go-version
++++ b/.go-version
+@@ -1 +1 @@
+-1.22.8
+\ No newline at end of file
++1.25.9
+\ No newline at end of file
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index 6a30a4d..306a07c 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.28.0-go1.22.8-bullseye.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 8328a46..04805c8 100644
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -97,7 +97,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_distroless_iptables_version=v0.5.9
+-readonly __default_go_runner_version=v2.3.1-go1.22.8-bookworm.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=bookworm-v1.0.3
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index 4da1f08..d6c68d7 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -114,7 +114,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.22.8
++    version: 1.25.9
+     refPaths:
+     - path: .go-version
+     - path: build/build-image/cross/VERSION
+@@ -137,7 +137,7 @@ dependencies:
+     #   match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "registry.k8s.io/kube-cross: dependents"
+-    version: v1.28.0-go1.22.8-bullseye.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -167,7 +167,7 @@ dependencies:
+       match: configs\[DistrolessIptables\] = Config{list\.BuildImageRegistry, "distroless-iptables", "v([0-9]+)\.([0-9]+)\.([0-9]+)"}
+ 
+   - name: "registry.k8s.io/go-runner: dependents"
+-    version: v2.3.1-go1.22.8-bookworm.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 1346086..f0584c1 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -2570,4 +2570,4 @@ rules:
+       dir: staging/src/k8s.io/endpointslice
+ recursive-delete-patterns:
+ - '*/.gitattributes'
+-default-go-version: 1.22.8
++default-go-version: 1.25.9
+diff --git a/test/images/Makefile b/test/images/Makefile
+index dfeec97..26d4d35 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= registry.k8s.io/e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.22.8
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/releases.yml
+++ b/releases.yml
@@ -231,6 +231,7 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - bump-go-1-25-9.1.28
       - CVE-2024-9042
       - CVE-2025-0426
       - CVE-2025-13281
@@ -298,6 +299,7 @@ releases:
     patches:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - bump-go-1-25-9.1.27
       - CVE-2024-10220
       - CVE-2024-9042
       - CVE-2025-0426
@@ -313,6 +315,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
+      - bump-go-1-25-9.1.26
       - CVE-2024-10220
       - CVE-2025-0426
       - CVE-2025-13281
@@ -329,6 +332,7 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
       - codegens-to-scripts.1.25
+      - bump-go-1-25-9.1.25
       - CVE-2024-10220
       - CVE-2025-0426
       - CVE-2025-13281


### PR DESCRIPTION
## Summary
- add Go bump patches for release-1.25, release-1.26, release-1.27, and release-1.28
- update the corresponding CI release chains in releases.yml to apply the new patches
- set Go-related pins to 1.25.9 (go version file, kube-cross/go-runner tags, publishing default, and test image Go version)

## Context
- follows the same approach used in workflow run 24446069133 for release-1.29 to release-1.32
- target requested: v1.25 to v1.28 use Go 1.25.9
