### PR TITLE
build: bump Go to 1.25.9 for release-1.21 / release-1.22 /  release-1.23 / release-1.24

### DIFF
--- a/patches/bump-go-1-25-9.1.21.patch
+++ b/patches/bump-go-1-25-9.1.21.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Thu, 16 Apr 2026 14:45:50 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.21
+
+---
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 5 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index c46549394a9..306a07c99c8 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.21.0-go1.16.15-buster.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 65737e9b22e..04eca13bb68 100755
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -87,7 +87,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_debian_iptables_version=buster-v1.6.7
+-readonly __default_go_runner_version=v2.3.1-go1.16.15-buster.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=buster-v2.0.4
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index c724110c919..076bcff6f71 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -101,7 +101,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.16.15
++    version: 1.25.9
+     refPaths:
+     - path: build/build-image/cross/VERSION
+     - path: cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+@@ -124,7 +124,7 @@ dependencies:
+       match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "k8s.gcr.io/kube-cross: dependents"
+-    version: v1.21.0-go1.16.15-buster.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+     - path: test/images/sample-apiserver/Makefile
+@@ -154,7 +154,7 @@ dependencies:
+       match: configs\[DebianIptables\] = Config{buildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
+ 
+   - name: "k8s.gcr.io/go-runner: dependents"
+-    version: v2.3.1-go1.16.15-buster.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 58b0faa1c88..183d3c9468e 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -7,7 +7,7 @@ recursive-delete-patterns:
+ - BUILD.bazel
+ - "*/BUILD.bazel"
+ - Gopkg.toml
+-default-go-version: 1.16.15
++default-go-version: 1.25.9
+ rules:
+ - destination: code-generator
+   branches:
+diff --git a/test/images/Makefile b/test/images/Makefile
+index b2a82160b36..e1ab5749b1d 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= gcr.io/kubernetes-e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.16.15
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/patches/bump-go-1-25-9.1.22.patch
+++ b/patches/bump-go-1-25-9.1.22.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Thu, 16 Apr 2026 14:45:50 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.22
+
+---
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 5 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index 0367120fe81..306a07c99c8 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.22.0-go1.16.15-buster.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 40954811d60..ac1aeb4f55b 100755
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -87,7 +87,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_debian_iptables_version=buster-v1.6.7
+-readonly __default_go_runner_version=v2.3.1-go1.16.15-buster.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=buster-v2.0.4
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index 4b68a24f03e..5713d4c6a51 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -101,7 +101,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.16.15
++    version: 1.25.9
+     refPaths:
+     - path: build/build-image/cross/VERSION
+     - path: cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+@@ -124,7 +124,7 @@ dependencies:
+       match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "k8s.gcr.io/kube-cross: dependents"
+-    version: v1.22.0-go1.16.15-buster.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -152,7 +152,7 @@ dependencies:
+       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
+ 
+   - name: "k8s.gcr.io/go-runner: dependents"
+-    version: v2.3.1-go1.16.15-buster.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 1279e5700a7..32be6af3257 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -7,7 +7,7 @@ recursive-delete-patterns:
+ - BUILD.bazel
+ - "*/BUILD.bazel"
+ - Gopkg.toml
+-default-go-version: 1.16.15
++default-go-version: 1.25.9
+ rules:
+ - destination: code-generator
+   branches:
+diff --git a/test/images/Makefile b/test/images/Makefile
+index b2a82160b36..e1ab5749b1d 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= gcr.io/kubernetes-e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.16.15
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/patches/bump-go-1-25-9.1.23.patch
+++ b/patches/bump-go-1-25-9.1.23.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Thu, 16 Apr 2026 14:45:50 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.23
+
+---
+ .go-version                     | 2 +-
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 6 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/.go-version b/.go-version
+index a85b56d4e7b..9b9ebced0e9 100644
+--- a/.go-version
++++ b/.go-version
+@@ -1 +1 @@
+-1.19.6
+\ No newline at end of file
++1.25.9
+\ No newline at end of file
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index 6cade01ef65..306a07c99c8 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.23.0-go1.19.6-bullseye.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 9d04eeedb7e..047e4c7cbe7 100755
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_debian_iptables_version=bullseye-v1.1.0
+-readonly __default_go_runner_version=v2.3.1-go1.19.6-bullseye.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=bullseye-v1.0.0
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index 6618098c20c..573933a35f8 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -87,7 +87,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.19.6
++    version: 1.25.9
+     refPaths:
+     - path: .go-version
+     - path: build/build-image/cross/VERSION
+@@ -119,7 +119,7 @@ dependencies:
+       match: 'GOLANG_VERSION\?=\d+.\d+(alpha|beta|rc)?\.?(\d+)?'
+ 
+   - name: "k8s.gcr.io/kube-cross: dependents"
+-    version: v1.23.0-go1.19.6-bullseye.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -149,7 +149,7 @@ dependencies:
+       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
+ 
+   - name: "k8s.gcr.io/go-runner: dependents"
+-    version: v2.3.1-go1.19.6-bullseye.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 0da2f6267bf..9c323eea414 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -7,7 +7,7 @@ recursive-delete-patterns:
+ - BUILD.bazel
+ - "*/BUILD.bazel"
+ - Gopkg.toml
+-default-go-version: 1.19.6
++default-go-version: 1.25.9
+ rules:
+ - destination: code-generator
+   branches:
+diff --git a/test/images/Makefile b/test/images/Makefile
+index c08d7406570..d640bd21505 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.19.6
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/patches/bump-go-1-25-9.1.24.patch
+++ b/patches/bump-go-1-25-9.1.24.patch
@@ -1,0 +1,99 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: codex <codex@local>
+Date: Thu, 16 Apr 2026 14:45:50 +0800
+Subject: [PATCH] build: bump Go to 1.25.9 for release-1.24
+
+---
+ .go-version                     | 2 +-
+ build/build-image/cross/VERSION | 2 +-
+ build/common.sh                 | 2 +-
+ build/dependencies.yaml         | 6 +++---
+ staging/publishing/rules.yaml   | 2 +-
+ test/images/Makefile            | 2 +-
+ 6 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/.go-version b/.go-version
+index 8909929f6e7..9b9ebced0e9 100644
+--- a/.go-version
++++ b/.go-version
+@@ -1 +1 @@
+-1.20.7
++1.25.9
+\ No newline at end of file
+diff --git a/build/build-image/cross/VERSION b/build/build-image/cross/VERSION
+index b4eeb4c4461..306a07c99c8 100644
+--- a/build/build-image/cross/VERSION
++++ b/build/build-image/cross/VERSION
+@@ -1 +1 @@
+-v1.24.0-go1.20.7-bullseye.0
++v1.33.0-go1.25.9-bullseye.0
+diff --git a/build/common.sh b/build/common.sh
+index 3c0c07217e1..03095a09dad 100755
+--- a/build/common.sh
++++ b/build/common.sh
+@@ -91,7 +91,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
+ 
+ # These are the default versions (image tags) for their respective base images.
+ readonly __default_debian_iptables_version=bullseye-v1.3.0
+-readonly __default_go_runner_version=v2.3.1-go1.20.7-bullseye.0
++readonly __default_go_runner_version=v2.4.0-go1.25.9-bookworm.0
+ readonly __default_setcap_version=bullseye-v1.2.0
+ 
+ # These are the base images for the Docker-wrapped binaries.
+diff --git a/build/dependencies.yaml b/build/dependencies.yaml
+index 7236ede3380..9fc233eff4d 100644
+--- a/build/dependencies.yaml
++++ b/build/dependencies.yaml
+@@ -88,7 +88,7 @@ dependencies:
+ 
+   # Golang
+   - name: "golang: upstream version"
+-    version: 1.20.7
++    version: 1.25.9
+     refPaths:
+     - path: .go-version
+     - path: build/build-image/cross/VERSION
+@@ -112,7 +112,7 @@ dependencies:
+     #  match: minimum_go_version=go([0-9]+\.[0-9]+)
+ 
+   - name: "k8s.gcr.io/kube-cross: dependents"
+-    version: v1.24.0-go1.20.7-bullseye.0
++    version: v1.33.0-go1.25.9-bullseye.0
+     refPaths:
+     - path: build/build-image/cross/VERSION
+ 
+@@ -142,7 +142,7 @@ dependencies:
+       match: configs\[DebianIptables\] = Config{list\.BuildImageRegistry, "debian-iptables", "[a-zA-Z]+\-v((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)"}
+ 
+   - name: "k8s.gcr.io/go-runner: dependents"
+-    version: v2.3.1-go1.20.7-bullseye.0
++    version: v2.4.0-go1.25.9-bookworm.0
+     refPaths:
+     - path: build/common.sh
+       match: __default_go_runner_version=
+diff --git a/staging/publishing/rules.yaml b/staging/publishing/rules.yaml
+index 9bf41ce0bca..62d64892849 100644
+--- a/staging/publishing/rules.yaml
++++ b/staging/publishing/rules.yaml
+@@ -8,7 +8,7 @@ recursive-delete-patterns:
+ - "*/BUILD.bazel"
+ - Gopkg.toml
+ - "*/.gitattributes"
+-default-go-version: 1.20.7
++default-go-version: 1.25.9
+ rules:
+ - destination: code-generator
+   branches:
+diff --git a/test/images/Makefile b/test/images/Makefile
+index 8191b84d6b0..d640bd21505 100644
+--- a/test/images/Makefile
++++ b/test/images/Makefile
+@@ -16,7 +16,7 @@ REGISTRY ?= k8s.gcr.io/e2e-test-images
+ GOARM ?= 7
+ DOCKER_CERT_BASE_PATH ?=
+ QEMUVERSION=v5.1.0-2
+-GOLANG_VERSION=1.20.7
++GOLANG_VERSION=1.25.9
+ export
+ 
+ ifndef WHAT

--- a/releases.yml
+++ b/releases.yml
@@ -349,6 +349,7 @@ releases:
       - no-delete-images.1.24
       - fix-etcd-put-key.1.24
       - codegens-to-scripts.1.24
+      - bump-go-1-25-9.1.24
       - CVE-2024-10220
       - CVE-2025-13281
       - CVE-2025-1767
@@ -363,6 +364,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - bump-go-1-25-9.1.23
       - CVE-2024-10220
       - CVE-2025-13281
       - CVE-2025-1767
@@ -377,6 +379,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - bump-go-1-25-9.1.22
       - CVE-2024-10220
       - CVE-2025-13281
       - CVE-2025-1767
@@ -391,6 +394,7 @@ releases:
       - fix-run-docker.1.24
       - no-delete-images.1.24
       - fix-etcd-put-key.1.23
+      - bump-go-1-25-9.1.21
       - CVE-2024-10220
       - CVE-2025-13281
       - CVE-2025-1767


### PR DESCRIPTION
## Summary
- add Go bump patches for release-1.21, release-1.22, release-1.23, and release-1.24
- update the corresponding CI release chains in releases.yml to apply the new patches
- set Go-related pins to 1.25.9 (go version file where present, kube-cross/go-runner tags, publishing default, and test image Go version)

## Following
- follows the patching pattern used in #230 (v1.29-v1.32) and #232 (v1.25-v1.28)
- rebased from latest main to avoid branch conflicts before submission

## Note on patch formatting
- formatter workflow was executed for these new patch files
- patch files are committed with formatter-aligned metadata style (full index hashes and executable mode metadata for build/common.sh)
